### PR TITLE
Fix missing SOFT functions on some platforms

### DIFF
--- a/openal/__init__.py
+++ b/openal/__init__.py
@@ -89,5 +89,15 @@ def get_dll_file():
     return dll.libfile
 
 
+def is_openal_soft():
+    """Returns True if openAL-soft features are available."""
+    from . import alc
+    expected = (
+        'alcResetDeviceSOFT',
+        'alcGetStringiSOFT',
+    )
+    return all(getattr(alc, key, None) is not None for key in expected)
+
+
 __version__ = "0.2.0"
 version_info = (0, 2, 0, "")

--- a/openal/alc.py
+++ b/openal/alc.py
@@ -26,8 +26,7 @@ __all__ = ["ALC_FALSE", "ALC_TRUE", "ALC_INVALID", "ALC_FREQUENCY",
            "alcGetError", "alcIsExtensionPresent", "alcGetProcAddress",
            "alcGetEnumValue", "alcGetString", "alcGetIntegerv",
            "alcCaptureOpenDevice", "alcCaptureCloseDevice", "alcCaptureStart",
-           "alcCaptureStop", "alcCaptureSamples", "alcGetStringiSOFT",
-           "alcResetDeviceSOFT",
+           "alcCaptureStop", "alcCaptureSamples",
            ]
 
 _bind = dll.bind_function
@@ -146,8 +145,14 @@ alcCaptureSamples = _bind("alcCaptureSamples", [ctypes.POINTER(ALCdevice),
                                                 ctypes.POINTER(ALCvoid),
                                                 ALCsizei])
 
-alcGetStringiSOFT = _bind("alcGetStringiSOFT", [ctypes.POINTER(ALCdevice),
-                                                  ctypes.POINTER(ALCenum),
-                                                  ctypes.POINTER(ALCsizei)])
-alcResetDeviceSOFT = _bind("alcResetDeviceSOFT", [ctypes.POINTER(ALCdevice),
-                                                  ctypes.POINTER(ALCint)])
+try:
+    alcGetStringiSOFT = _bind("alcGetStringiSOFT", [ctypes.POINTER(ALCdevice),
+                                                      ctypes.POINTER(ALCenum),
+                                                      ctypes.POINTER(ALCsizei)])
+    alcResetDeviceSOFT = _bind("alcResetDeviceSOFT", [ctypes.POINTER(ALCdevice),
+                                                      ctypes.POINTER(ALCint)])
+except AttributeError:
+    import logging
+    logging.warning('alcGetStringiSOFT and alcResetDeviceSOFT not supported on this platform')
+else:
+    __all__.extend(('alcGetStringiSOFT', 'alcResetDeviceSOFT'))

--- a/openal/alc.py
+++ b/openal/alc.py
@@ -1,5 +1,6 @@
 import ctypes
 from . import dll
+from .log import logger
 
 __all__ = ["ALC_FALSE", "ALC_TRUE", "ALC_INVALID", "ALC_FREQUENCY",
            "ALC_REFRESH", "ALC_SYNC", "ALC_MONO_SOURCES", "ALC_STEREO_SOURCES",
@@ -152,7 +153,6 @@ try:
     alcResetDeviceSOFT = _bind("alcResetDeviceSOFT", [ctypes.POINTER(ALCdevice),
                                                       ctypes.POINTER(ALCint)])
 except AttributeError:
-    import logging
-    logging.warning('alcGetStringiSOFT and alcResetDeviceSOFT not supported on this platform')
+    logger.warning('openAL-soft functions could not be bound')
 else:
     __all__.extend(('alcGetStringiSOFT', 'alcResetDeviceSOFT'))

--- a/openal/log.py
+++ b/openal/log.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger('PyAL')


### PR DESCRIPTION
On OS X, the alcGetStringiSOFT and alcResetDeviceSOFT functions are not available.

This change makes the absence of these functions a warning instead of a fatal error.

PyAL implementations can be made portable by wrapping use of these functions in a try block, e.g.

```
alc.alcResetDeviceSOFT(sink.device, None)
hrtf_buffers = [alc.ALCint(),alc.ALCint*4,alc.ALCint()]
hrtf_select = hrtf_buffers[1](alc.ALC_HRTF_SOFT,alc.ALC_TRUE,alc.ALC_HRTF_ID_SOFT,alc.ALC_HRTF_DISABLED_SOFT)
alc.alcResetDeviceSOFT(sink.device, hrtf_select)
```

becomes:

```
try:
    alc.alcResetDeviceSOFT(sink.device, None)
    hrtf_buffers = [alc.ALCint(),alc.ALCint*4,alc.ALCint()]
    hrtf_select = hrtf_buffers[1](alc.ALC_HRTF_SOFT,alc.ALC_TRUE,alc.ALC_HRTF_ID_SOFT,alc.ALC_HRTF_DISABLED_SOFT)
    alc.alcResetDeviceSOFT(sink.device, hrtf_select)
except AttributeError:
    print('print a warning here')
```